### PR TITLE
fix: corrige la lógica de colocación de bloques en regiones temporales

### DIFF
--- a/src/main/java/com/xiluiis/temporaryprotections/ConfigManager.java
+++ b/src/main/java/com/xiluiis/temporaryprotections/ConfigManager.java
@@ -1,5 +1,25 @@
 package com.xiluiis.temporaryprotections;
 
+//import org.bukkit.configuration.file.FileConfiguration;
+import java.util.List;
+
 public class ConfigManager {
-    
+    private final TemporaryProtections plugin;
+
+    public ConfigManager(TemporaryProtections plugin) {
+        this.plugin = plugin;
+        plugin.saveDefaultConfig();
+    }
+
+    public int getTemporaryProtectionSeconds() {
+        return plugin.getConfig().getInt("temporary-protection-seconds", 60);
+    }
+
+    public boolean isDebugEnabled() {
+        return plugin.getConfig().getBoolean("debug-messages", false);
+    }
+
+    public List<String> getAllowedProtectionBlocks() {
+        return plugin.getConfig().getStringList("allowed-protection-blocks");
+    }
 }

--- a/src/main/java/com/xiluiis/temporaryprotections/TemporaryProtections.java
+++ b/src/main/java/com/xiluiis/temporaryprotections/TemporaryProtections.java
@@ -9,8 +9,8 @@
 
 package com.xiluiis.temporaryprotections;
 
-import com.xiluiis.temporaryprotections.TemporaryRegionManager;
-import com.xiluiis.temporaryprotections.ProtectionListener;
+// import com.xiluiis.temporaryprotections.TemporaryRegionManager;
+// import com.xiluiis.temporaryprotections.ProtectionListener;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -29,13 +29,15 @@ import java.util.*;
 public class TemporaryProtections extends JavaPlugin implements Listener {
 
     private final Map<UUID, Set<String>> playerEvents = new HashMap<>();
+    private ConfigManager configManager; // <--- referencia global
 
     @Override
     public void onEnable() {
-        
+        saveDefaultConfig(); // <--- Esto asegura que config.yml exista
+
+        configManager = new ConfigManager(this);
         TemporaryRegionManager regionManager = new TemporaryRegionManager(this);
-        
-        Bukkit.getPluginManager().registerEvents(new ProtectionListener(this, regionManager), this);
+        Bukkit.getPluginManager().registerEvents(new ProtectionListener(this, regionManager, configManager), this);
 
         this.getCommand("tmpp").setExecutor(this);
         getLogger().info("Plugin TemporaryProtections activado.");
@@ -68,12 +70,12 @@ public class TemporaryProtections extends JavaPlugin implements Listener {
     }
 
     private void mostrarAyuda(Player player) {
-        player.sendMessage(ChatColor.AQUA + "=== tp Help ===");
+        player.sendMessage(ChatColor.AQUA + "=== TemporaryProtections Help ===");
         player.sendMessage(ChatColor.YELLOW + "/tmpp help" + ChatColor.WHITE + " - Muestra este mensaje.");
-        player.sendMessage(ChatColor.YELLOW + "/tmpp enable <evento> yes|no" + ChatColor.WHITE + " - Activa o desactiva un evento.");
+        player.sendMessage(ChatColor.YELLOW + "/tmpp enable <evento> yes | no" + ChatColor.WHITE + " - Activa o desactiva un evento.");
         player.sendMessage(ChatColor.GRAY + "Ejemplo: /tmpp enable blockcoords yes");
         player.sendMessage(ChatColor.YELLOW + "Eventos disponibles: blockcoords");
-        player.sendMessage(ChatColor.YELLOW + "Usa /tmpp debug para ver el estado de ProtectionStones.");
+        player.sendMessage(ChatColor.YELLOW + "Usa /tmpp debug para ver el estado de ProtectionStones y más datos.");
     }
 
     private void ejecutarDebug(Player player) {
@@ -122,5 +124,5 @@ public class TemporaryProtections extends JavaPlugin implements Listener {
             player.sendMessage(ChatColor.YELLOW + "Uso: /tmpp enable <evento> yes|no");
         }
     }
-
+    
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,5 @@
 # config.yml
 temporary-protection-seconds: 60
 debug-messages: true
+allowed-protection-blocks:
+  - "64"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,6 +6,6 @@ version: 1.0
 api-version: 1.20
 depend: [WorldGuard]
 commands:
-  tp:
+  tmpp:
     description: Activa o desactiva el modo de eventos
     usage: /tmpp events yes|no


### PR DESCRIPTION
- Ahora solo se permite colocar bloques de protección cuyo alias esté en la lista de configuración dentro de regiones temporales.
- Se corrige el filtro para evitar que bloques no permitidos puedan crear o eliminar regiones temporales.
- Se mantiene la protección para que ningún otro bloque (incluyendo otros bloques de protección no permitidos) pueda colocarse en regiones temporales.
- Se muestra al jugador el alias del bloque de protección colocado (solo para debug).